### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1563,7 +1563,7 @@ class AnsibleModule(object):
                 # No pipes are left to read but process is not yet terminated
                 # Only then it is safe to wait for the process to be finished
                 # NOTE: Actually cmd.poll() is always None here if rpipes is empty
-                elif not rpipes and cmd.poll() == None:
+                elif not rpipes and cmd.poll() is None:
                     cmd.wait()
                     # The process is terminated. Since no pipes to read from are
                     # left, there is no need to call select() again.

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -193,7 +193,7 @@ class Connection(object):
             # No pipes are left to read but process is not yet terminated
             # Only then it is safe to wait for the process to be finished
             # NOTE: Actually p.poll() is always None here if rpipes is empty
-            elif not rpipes and p.poll() == None:
+            elif not rpipes and p.poll() is None:
                 p.wait()
                 # The process is terminated. Since no pipes to read from are
                 # left, there is no need to call select() again.

--- a/lib/ansible/utils/cmd_functions.py
+++ b/lib/ansible/utils/cmd_functions.py
@@ -53,7 +53,7 @@ def run_cmd(cmd, live=False, readsize=10):
         if (not rpipes or not rfd) and p.poll() is not None:
             break
         # Calling wait while there are still pipes to read can cause a lock
-        elif not rpipes and p.poll() == None:
+        elif not rpipes and p.poll() is None:
             p.wait()
 
     return p.returncode, stdout, stderr

--- a/plugins/inventory/abiquo.py
+++ b/plugins/inventory/abiquo.py
@@ -55,7 +55,7 @@ except ImportError:
 
 def api_get(link, config):
     try:
-        if link == None:
+        if link is None:
             request = urllib2.Request(config.get('api','uri')+config.get('api','login_path'))
             request.add_header("Accept",config.get('api','login_type'))
         else:
@@ -150,7 +150,7 @@ def generate_inv_from_api(enterprise_entity,config):
             if ((config.getboolean('defaults', 'deployed_only') == True) and (vmcollection['state'] == 'NOT_ALLOCATED')):
                 vm_state = False
 
-            if not vm_nic == None and vm_state:
+            if not vm_nic is None and vm_state:
                 if not vm_vapp in inventory.keys():
                     inventory[vm_vapp] = {}
                     inventory[vm_vapp]['children'] = []

--- a/plugins/inventory/consul_io.py
+++ b/plugins/inventory/consul_io.py
@@ -341,7 +341,7 @@ class ConsulInventory(object):
 
     new_dict = {}
     for k, v in d.items():
-      if v != None:
+      if v is not None:
         new_dict[self.to_safe(str(k))] = self.to_safe(str(v))
     return new_dict
 

--- a/plugins/inventory/digital_ocean.py
+++ b/plugins/inventory/digital_ocean.py
@@ -469,7 +469,7 @@ or environment variables (DO_CLIENT_ID and DO_API_KEY)'''
     def sanitize_dict(self, d):
         new_dict = {}
         for k, v in d.items():
-            if v != None:
+            if v is not None:
                 new_dict[self.to_safe(str(k))] = self.to_safe(str(v))
         return new_dict
 

--- a/test/units/TestFilters.py
+++ b/test/units/TestFilters.py
@@ -67,7 +67,7 @@ class TestFilters(unittest.TestCase):
 
     def test_bool_none(self):
         a = ansible.runner.filter_plugins.core.bool(None)
-        assert a == None
+        assert a is None
 
     def test_bool_true(self):
         a = ansible.runner.filter_plugins.core.bool(True)

--- a/test/units/TestSynchronize.py
+++ b/test/units/TestSynchronize.py
@@ -72,7 +72,7 @@ class TestSynchronize(unittest.TestCase):
 
         assert runner.executed_inject['delegate_to'] == "127.0.0.1", "was not delegated to 127.0.0.1"
         assert runner.executed_complex_args == {"dest":"root@el6.lab.net:/tmp/bar", "src":"/tmp/foo"}, "wrong args used"
-        assert runner.sudo == None, "sudo was not reset to None" 
+        assert runner.sudo is None, "sudo was not reset to None" 
 
     def test_synchronize_action_sudo(self):
 

--- a/v2/ansible/galaxy/api.py
+++ b/v2/ansible/galaxy/api.py
@@ -104,13 +104,13 @@ class GalaxyAPI(object):
             url = '%s/roles/%d/%s/?page_size=50' % (self.baseurl, int(role_id), related)
             data = json.load(urlopen(url))
             results = data['results']
-            done = (data.get('next', None) == None)
+            done = (data.get('next', None) is None)
             while not done:
                 url = '%s%s' % (self.baseurl, data['next'])
                 self.galaxy.display.display(url)
                 data = json.load(urlopen(url))
                 results += data['results']
-                done = (data.get('next', None) == None)
+                done = (data.get('next', None) is None)
             return results
         except:
             return None
@@ -129,13 +129,13 @@ class GalaxyAPI(object):
                 results = data
             done = True
             if "next" in data:
-                done = (data.get('next', None) == None)
+                done = (data.get('next', None) is None)
             while not done:
                 url = '%s%s' % (self.baseurl, data['next'])
                 self.galaxy.display.display(url)
                 data = json.load(urlopen(url))
                 results += data['results']
-                done = (data.get('next', None) == None)
+                done = (data.get('next', None) is None)
             return results
         except Exception as error:
             raise AnsibleError("Failed to download the %s list: %s" % (what, str(error)))

--- a/v2/ansible/module_utils/basic.py
+++ b/v2/ansible/module_utils/basic.py
@@ -1550,7 +1550,7 @@ class AnsibleModule(object):
                 # No pipes are left to read but process is not yet terminated
                 # Only then it is safe to wait for the process to be finished
                 # NOTE: Actually cmd.poll() is always None here if rpipes is empty
-                elif not rpipes and cmd.poll() == None:
+                elif not rpipes and cmd.poll() is None:
                     cmd.wait()
                     # The process is terminated. Since no pipes to read from are
                     # left, there is no need to call select() again.

--- a/v2/ansible/plugins/connections/ssh.py
+++ b/v2/ansible/plugins/connections/ssh.py
@@ -207,7 +207,7 @@ class Connection(ConnectionBase):
             # No pipes are left to read but process is not yet terminated
             # Only then it is safe to wait for the process to be finished
             # NOTE: Actually p.poll() is always None here if rpipes is empty
-            elif not rpipes and p.poll() == None:
+            elif not rpipes and p.poll() is None:
                 p.wait()
                 # The process is terminated. Since no pipes to read from are
                 # left, there is no need to call select() again.


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:ansible?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:ansible?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
