### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/lib/ansible/cache/__init__.py
+++ b/lib/ansible/cache/__init__.py
@@ -51,7 +51,7 @@ class FactCache(MutableMapping):
 
     def copy(self):
         """ Return a primitive copy of the keys and values from the cache. """
-        return dict([(k, v) for (k, v) in self.iteritems()])
+        return {k: v for (k, v) in self.iteritems()}
 
     def keys(self):
         return self._plugin.keys()

--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -160,7 +160,7 @@ class InventoryDirectory(object):
 
         # hosts list (host objects are by now already added to self.hosts)
         for host in newgroup.hosts:
-            grouphosts = dict([(h.name, h) for h in group.hosts])
+            grouphosts = {h.name: h for h in group.hosts}
             if host.name in grouphosts:
                 # same host name but different object, merge
                 self._merge_hosts(grouphosts[host.name], host)
@@ -178,7 +178,7 @@ class InventoryDirectory(object):
         # group child membership relation
         for newchild in newgroup.child_groups:
             # dict with existing child groups:
-            childgroups = dict([(g.name, g) for g in group.child_groups])
+            childgroups = {g.name: g for g in group.child_groups}
             # check if child of new group is already known as a child
             if newchild.name not in childgroups:
                 self.groups[group.name].add_child_group(newchild)
@@ -186,7 +186,7 @@ class InventoryDirectory(object):
         # group parent membership relation
         for newparent in newgroup.parent_groups:
             # dict with existing parent groups:
-            parentgroups = dict([(g.name, g) for g in group.parent_groups])
+            parentgroups = {g.name: g for g in group.parent_groups}
             # check if parent of new group is already known as a parent
             if newparent.name not in parentgroups:
                 if newparent.name not in self.groups:
@@ -208,7 +208,7 @@ class InventoryDirectory(object):
         # group membership relation
         for newgroup in newhost.groups:
             # dict with existing groups:
-            hostgroups = dict([(g.name, g) for g in host.groups])
+            hostgroups = {g.name: g for g in host.groups}
             # check if new group is already known as a group
             if newgroup.name not in hostgroups:
                 if newgroup.name not in self.groups:

--- a/plugins/inventory/spacewalk.py
+++ b/plugins/inventory/spacewalk.py
@@ -121,7 +121,7 @@ if options.list:
         for group, systems in groups.iteritems():
             print '[%s]\n%s\n' % (group, '\n'.join(systems))
     else:
-        print json.dumps(dict([ (k, list(s)) for k, s in groups.iteritems() ]))
+        print json.dumps({k: list(s) for k, s in groups.iteritems()})
 
     sys.exit(0)
 

--- a/v2/ansible/inventory/dir.py
+++ b/v2/ansible/inventory/dir.py
@@ -167,7 +167,7 @@ class InventoryDirectory(object):
 
         # hosts list (host objects are by now already added to self.hosts)
         for host in newgroup.hosts:
-            grouphosts = dict([(h.name, h) for h in group.hosts])
+            grouphosts = {h.name: h for h in group.hosts}
             if host.name in grouphosts:
                 # same host name but different object, merge
                 self._merge_hosts(grouphosts[host.name], host)
@@ -185,7 +185,7 @@ class InventoryDirectory(object):
         # group child membership relation
         for newchild in newgroup.child_groups:
             # dict with existing child groups:
-            childgroups = dict([(g.name, g) for g in group.child_groups])
+            childgroups = {g.name: g for g in group.child_groups}
             # check if child of new group is already known as a child
             if newchild.name not in childgroups:
                 self.groups[group.name].add_child_group(newchild)
@@ -193,7 +193,7 @@ class InventoryDirectory(object):
         # group parent membership relation
         for newparent in newgroup.parent_groups:
             # dict with existing parent groups:
-            parentgroups = dict([(g.name, g) for g in group.parent_groups])
+            parentgroups = {g.name: g for g in group.parent_groups}
             # check if parent of new group is already known as a parent
             if newparent.name not in parentgroups:
                 if newparent.name not in self.groups:
@@ -215,7 +215,7 @@ class InventoryDirectory(object):
         # group membership relation
         for newgroup in newhost.groups:
             # dict with existing groups:
-            hostgroups = dict([(g.name, g) for g in host.groups])
+            hostgroups = {g.name: g for g in host.groups}
             # check if new group is already known as a group
             if newgroup.name not in hostgroups:
                 if newgroup.name not in self.groups:

--- a/v2/ansible/plugins/cache/__init__.py
+++ b/v2/ansible/plugins/cache/__init__.py
@@ -52,7 +52,7 @@ class FactCache(MutableMapping):
 
     def copy(self):
         """ Return a primitive copy of the keys and values from the cache. """
-        return dict([(k, v) for (k, v) in self.iteritems()])
+        return {k: v for (k, v) in self.iteritems()}
 
     def keys(self):
         return self._plugin.keys()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:ansible?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:ansible?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
